### PR TITLE
chore: Koog 0.4.1へのアップグレード（最新版）

### DIFF
--- a/app/gradle/libs.versions.toml
+++ b/app/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ spring-boot-management = "1.1.7"
 kotlin-logging-jvm = "3.0.5"
 kotlinx-serialization-json="1.8.1"
 kotlinx-coroutines = "1.10.2"
-koog-agents = "0.3.0"
+koog-agents = "0.4.1"
 
 [libraries]
 spring-boot-starter = { module = "org.springframework.boot:spring-boot-starter" }


### PR DESCRIPTION
## 概要
Koogライブラリを0.3.0から最新版の0.4.1にアップグレードしました。

## 変更内容
- `libs.versions.toml`でkoog-agentsのバージョンを0.3.0→0.4.1に更新

## Koog 0.4.0の主な新機能
### 🎯 新機能
- **Observability統合**: Langfuse span adapters、Weights & Biases (W&B) Weave統合
- **プラットフォーム拡張**: Ktorプラグイン、iOSネイティブターゲットサポート
- **レジリエンス改善**: LLMクライアントのリトライロジック追加

### 💔 破壊的変更
- Google Gemini 1.5モデルバリアントの削除
- PromptExecutorの`execute`拡張メソッドの削除
- ファイルシステムAPIのクリーンアップ（インターフェース、メソッドのリネーム）

### 📦 依存関係
- kotlin-mcpを0.6.0にアップデート

## Koog 0.4.1の修正
- iOSターゲットのパブリケーション問題を修正

## テスト結果
- ✅ ビルド成功
- ✅ アプリケーション起動確認
- ✅ ヘルスチェックエンドポイント正常応答

## 参考
- [Koog 0.4.0 リリースノート](https://github.com/JetBrains/koog/releases/tag/0.4.0)
- [Koog 0.4.1 リリースノート](https://github.com/JetBrains/koog/releases/tag/0.4.1)

🤖 Generated with [Claude Code](https://claude.ai/code)